### PR TITLE
Add Discord linking

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -14,16 +14,14 @@ module.exports = {
 				iconURL: 'https://i.imgur.com/lSwBDLb.png',
 				url: 'https://utdmaker.space/'
 			})
-			.setThumbnail(
-				'https://cdn.discordapp.com/avatars/628033792505806868/bea690b7691970aecf066edd9d3c9fe1.png?size=512'
-			)
-			.setTitle('Bit-Bot v1')
+			.setThumbnail('https://i.imgur.com/lSwBDLb.png')
+			.setTitle('BitBot')
 			.setDescription(
-				'The UTDesign Makerspace Bot (Bit-Bot) has commands for controlling, monitoring, and learning about the makerspace.'
+				'BitBot is the official UTDesign Makerspace Discord bot. It has commands for controlling, monitoring, and learning more about the Makerspace.'
 			)
 			.addField(
 				'3D Printing',
-				'Check the status of printers at any time using /status. Link your Discord and UTDesign Makerspace accounts to receive notifications for your 3D prints.'
+				'Check the status of printers at any time using /status. Link your Discord and UTDesign Makerspace accounts using /link to receive notifications for your 3D prints.'
 			);
 		interaction.editReply({ embeds: [helpEmbed], ephemeral: true });
 	}

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -12,7 +12,7 @@ module.exports = {
 		const { entries: users } = await client.searchReturnAll(
 			process.env.LDAP_MEMBERS_BASE,
 			{
-				filter: `(cn=${username})`,
+				filter: `(uid=${username})`,
 				scope: 'sub',
 				attributes
 			}
@@ -21,7 +21,7 @@ module.exports = {
 	},
 	getUserByDiscord: async function (
 		discordId,
-		attributes = ['cometcard', 'givenName', 'sn', 'mail', 'cn', 'username']
+		attributes = ['cometcard', 'givenName', 'sn', 'mail', 'cn', 'uid']
 	) {
 		await client.bind(process.env.LDAP_BIND_DN, process.env.LDAP_BIND_PASS);
 		const { entries: users } = await client.searchReturnAll(
@@ -34,7 +34,7 @@ module.exports = {
 		);
 		return users[0];
 	},
-	getGroupsByUsername: async function (username, attributes = ['cn']) {
+	getGroupsByUsername: async function (username, attributes = ['cn', 'uid']) {
 		await client.bind(process.env.LDAP_BIND_DN, process.env.LDAP_BIND_PASS);
 		const { entries: groups } = await client.searchReturnAll(
 			process.env.LDAP_GROUPS_BASE,
@@ -59,12 +59,12 @@ module.exports = {
 			return;
 		}
 		const members = data.entries[0].member;
-		const full_username = "uid=" + username + "," + process.env.LDAP_MEMBERS_BASE;
+		const full_username =
+			'uid=' + username + ',' + process.env.LDAP_MEMBERS_BASE;
 		if (members.includes(full_username)) {
 			console.log('User already in group');
 			return;
 		}
-		
 
 		const change = new ldap.Change({
 			operation: 'add',
@@ -75,6 +75,21 @@ module.exports = {
 
 		await client.modify(
 			`cn=${group},${process.env.LDAP_GROUPS_BASE}`,
+			change
+		);
+	},
+	linkUserToDiscord: async function (username, discordId) {
+		await client.bind(process.env.LDAP_BIND_DN, process.env.LDAP_BIND_PASS);
+
+		const change = new ldap.Change({
+			operation: 'add',
+			modification: {
+				discord: discordId
+			}
+		});
+
+		await client.modify(
+			`uid=${username},${process.env.LDAP_MEMBERS_BASE}`,
 			change
 		);
 	}

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -31,11 +31,11 @@ module.exports = {
 			// Otherwise, assuming there is a linked account...
 
 			// Grab their groups
-			const groups = await ldap.getGroupsByUsername(ldapMember.cn);
+			const groups = await ldap.getGroupsByUsername(ldapMember.uid);
 
 			// Create the base embed
 			profileEmbed
-				.setTitle(`${ldapMember.givenName} ${ldapMember.sn}`)
+				.setTitle(`${ldapMember.cn}`)
 				.addField('Bits', 'WIP', true)
 				.addField('Total Bits', 'WIP', true);
 
@@ -60,7 +60,7 @@ module.exports = {
 			let trainings = '';
 			if (groups.some((group) => group.cn === 'trained-3dprinting'))
 				trainings += '3D Printing\n';
-			if (groups.some((group) => group.cn === 'trained-lasercutting'))
+			if (groups.some((group) => group.cn === 'trained-laser'))
 				trainings += 'Laser Cutting\n';
 			if (trainings) profileEmbed.addField('Training', trainings, false);
 


### PR DESCRIPTION
Adds the ability for users to link their Discord accounts through BitBot directly rather than using an external service. This is a temporary solution until a web portal is established or the decision is made that a web portal is unnecessary.